### PR TITLE
UUID fix for Android

### DIFF
--- a/webbluetooth.js
+++ b/webbluetooth.js
@@ -954,7 +954,6 @@
 
       const scan = function (idx) {
         const scanIDs = idx > -1 ? [serviceUUIDs[idx]] : serviceUUIDs;
-        console.log("Scanning for " + scanIDs);
         evothings.ble.stopScan();
         evothings.ble.startScan(
           scanIDs,
@@ -974,7 +973,7 @@
         adapter.scanLoopTimeout = setTimeout(function () {
           loopIdx = (loopIdx + 1) % serviceUUIDs.length;
           scanLoop();
-        }, 2000);
+        }, 1000);
 
       };
 

--- a/webbluetooth.js
+++ b/webbluetooth.js
@@ -966,21 +966,26 @@
             if (errorFn) { errorFn(error); }
           });
         if (completeFn) { completeFn(); }
-      }
+      };
+
       const scanLoop = function (idx) {
         console.log("Loop idx: " + idx + " has UUID: " + serviceUUIDs[idx]);
         scan(idx);
         adapter.scanLoopTimeout = setTimeout(function () {
           scanLoop((idx + 1) % serviceUUIDs.length);
         }, 250);
-      }
-      if (serviceUUIDs.length > 1 && (device.platform === "Android")) {
-        console.log("scanning first UUID");
-        scanLoop(0);
-      } else {
-        console.log("scanning all UUIDs");
-        scan(-1);
-      }
+      };
+
+      // Scan each uuid in turn, starting with the first
+      scanLoop(0);
+
+      // if (serviceUUIDs.length > 1 && (device.platform === "Android")) {
+      //   console.log("scanning first UUID");
+      //   scanLoop(0);
+      // } else {
+      //   console.log("scanning all UUIDs");
+      //   scan(-1);
+      // }
     });
   };
 

--- a/webbluetooth.js
+++ b/webbluetooth.js
@@ -935,8 +935,9 @@
 
   adapter.scanLoopTimeout = null;
   adapter.stopScanLoop = function (callback) {
-    console.log("Stopping scan loop");
-    clearTimeout(adapter.scanLoopTimeout);
+    if (adapter.scanLoopTimeout) {
+      clearTimeout(adapter.scanLoopTimeout);
+    }
     if (callback) callback();
   }
 
@@ -949,7 +950,7 @@
     )
   {
     init(function () {
-      console.log("init called for android? " + platformIsAndroid(), serviceUUIDs);
+      let loopIdx = 0;
 
       const scan = function (idx) {
         const scanIDs = idx > -1 ? [serviceUUIDs[idx]] : serviceUUIDs;
@@ -968,24 +969,20 @@
         if (completeFn) { completeFn(); }
       };
 
-      const scanLoop = function (idx) {
-        console.log("Loop idx: " + idx + " has UUID: " + serviceUUIDs[idx]);
-        scan(idx);
+      const scanLoop = function () {
+        scan(loopIdx);
         adapter.scanLoopTimeout = setTimeout(function () {
-          scanLoop((idx + 1) % serviceUUIDs.length);
+          loopIdx = (loopIdx + 1) % serviceUUIDs.length;
+          scanLoop();
         }, 2000);
+
       };
 
-      // Scan each uuid in turn, starting with the first
-      scanLoop(0);
-
-      // if (serviceUUIDs.length > 1 && (device.platform === "Android")) {
-      //   console.log("scanning first UUID");
-      //   scanLoop(0);
-      // } else {
-      //   console.log("scanning all UUIDs");
-      //   scan(-1);
-      // }
+      if (platformIsAndroid() && serviceUUIDs.length > 1) {
+        scanLoop();
+      } else {
+        scan(-1);
+      }
     });
   };
 

--- a/webbluetooth.js
+++ b/webbluetooth.js
@@ -949,7 +949,7 @@
     )
   {
     init(function () {
-      console.log("init called", serviceUUIDs);
+      console.log("init called for android? " + platformIsAndroid(), serviceUUIDs);
 
       const scan = function (idx) {
         const scanIDs = idx > -1 ? [serviceUUIDs[idx]] : serviceUUIDs;
@@ -973,7 +973,7 @@
         scan(idx);
         adapter.scanLoopTimeout = setTimeout(function () {
           scanLoop((idx + 1) % serviceUUIDs.length);
-        }, 250);
+        }, 2000);
       };
 
       // Scan each uuid in turn, starting with the first

--- a/webbluetooth.js
+++ b/webbluetooth.js
@@ -935,6 +935,7 @@
 
   adapter.scanLoopTimeout = null;
   adapter.stopScanLoop = function (callback) {
+    console.log("Stopping scan loop");
     clearTimeout(adapter.scanLoopTimeout);
     if (callback) callback();
   }
@@ -948,11 +949,14 @@
     )
   {
     init(function () {
-      const scan = function (uuid, serviceUUIDs) {
-        console.log("Scanning for " + serviceUUIDS ? serviceUUIDs : [uuid]);
+      console.log("init called", serviceUUIDs);
+
+      const scan = function (idx) {
+        const scanIDs = idx > -1 ? [serviceUUIDs[idx]] : serviceUUIDs;
+        console.log("Scanning for " + scanIDs);
         evothings.ble.stopScan();
         evothings.ble.startScan(
-          serviceUUIDS ? serviceUUIDs : [uuid],
+          scanIDs,
           function (deviceInfo) {
             adapter.stopScanLoop();
             if (foundFn) { foundFn(createBleatDeviceObject(deviceInfo)); }
@@ -964,15 +968,18 @@
         if (completeFn) { completeFn(); }
       }
       const scanLoop = function (idx) {
-        scan(serviceUUIDs[idx]);
+        console.log("Loop idx: " + idx + " has UUID: " + serviceUUIDs[idx]);
+        scan(idx);
         adapter.scanLoopTimeout = setTimeout(function () {
-          scan((idx + 1) % serviceUUIDs.length);
+          scanLoop((idx + 1) % serviceUUIDs.length);
         }, 250);
       }
       if (serviceUUIDs.length > 1 && (device.platform === "Android")) {
+        console.log("scanning first UUID");
         scanLoop(0);
       } else {
-        scan(serviceUUIDs[0], serviceUUIDs);
+        console.log("scanning all UUIDs");
+        scan(-1);
       }
     });
   };


### PR DESCRIPTION
Due to the way Android handles searching for multiple types of sensor (using an AND that essentially looked for devices with both IDs instead of an OR), this PR changes the behavior on Android to continuously search one type of sensor for 2s then switches to the next type of sensor. As soon as a compatible sensor device is found, the loop ends.

@dougmartin you helped write most of this code (thanks!), the changes since you last saw it are a couple of minor tweaks and the check for platform.